### PR TITLE
Fix: Back button now goes to previous Url 

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { BrowserRouter as Router, Route, Switch, Redirect, useParams } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch, Redirect, useParams, useLocation } from 'react-router-dom';
 import './App.css';
 import CountyDetail from './components/CountyDetail';
 import SearchBar from './components/SearchBar';
@@ -38,6 +38,10 @@ function App() {
 function HomePage() {
   let baseUri = "https://cors-anywhere.gradyt.com/https://covercovid-19.com/saved?";
   const savedLocations = JSON.parse(localStorage.getItem("counties"));
+
+  // Track the previous URL accessed
+  let prevUrl = useLocation().pathname;
+  localStorage.setItem("prevUrl", prevUrl);
 
   if (savedLocations) {
     savedLocations.map((id) => {
@@ -105,6 +109,10 @@ function SearchPage() {
   const baseUri = "https://cors-anywhere.gradyt.com/https://covercovid-19.com/search/" + county;
   const [counties, setCounties] = useState([]);
   const [loaded, setLoaded] = useState(false);
+
+  // Track the previous URL accessed
+  let prevUrl = useLocation().pathname;
+  localStorage.setItem("prevUrl", prevUrl);
 
   useEffect(() => {
     fetch(baseUri, {

--- a/my-app/src/components/CountyDetail.js
+++ b/my-app/src/components/CountyDetail.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect }from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import LineGraph from './LineGraph';
 import SearchBar from './SearchBar';
 import { Ring } from 'react-awesome-spinners';
@@ -20,6 +20,8 @@ export default function CountyDetail() {
     const [isSaved, setSaved] = useState(false);
     const [loaded, setLoaded] = useState(false);
     const requestUri = "https://cors-anywhere.gradyt.com/https://covercovid-19.com/county/" + county + "/" + state;
+
+    let prevUrl = localStorage.getItem("prevUrl") ? localStorage.getItem("prevUrl") : '/';
   
     useEffect(() => {
       fetch(requestUri).then((response) => response.json())
@@ -76,7 +78,7 @@ export default function CountyDetail() {
         <div className="county-page">
           <div className={"county-header county-" + risk}>
               <div>
-                <a className="back" href={'/search/' + county}><span className="material-icons detail-button">arrow_back</span></a>
+                <a className="back" href={prevUrl}><span className="material-icons detail-button">arrow_back</span></a>
               </div>
               <div>
                 <h2>{county} County, {state}</h2>


### PR DESCRIPTION
This PR uses localStorage to now keep track of the previous URL visited in regards to the home page or search page. Enabling the use of the back button to navigate backwards to those pages.